### PR TITLE
Remove js-base64 dependency

### DIFF
--- a/lib/validation/format-generators.js
+++ b/lib/validation/format-generators.js
@@ -25,12 +25,7 @@
 'use strict';
 
 var _ = require('lodash');
-var Base64 = require('js-base64');
-
-// Due to the differences in how node.js and the browser use js-base64, we need this hack
-if (typeof Base64.Base64 !== 'undefined') {
-  Base64 = Base64.Base64;
-}
+var buffer = require('buffer');
 
 /**
  * We have to filter the schema to avoid a maximum callstack issue by deleting the format property.
@@ -50,7 +45,9 @@ function filterSchema (schema) {
 // Build the list of custom JSON Schema generator formats
 module.exports.byte = function (mocker) {
   return function (schema) {
-    return Base64.encode(mocker.generate(filterSchema(schema)));
+    return buffer.Buffer.from(mocker.generate(filterSchema(schema))).toString(
+      'base64'
+    );
   };
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "debug": "^3.1.0",
         "faker": "^4.1.0",
-        "js-base64": "^2.4.5",
         "js-yaml": "^3.13.1",
         "json-refs": "^3.0.13",
         "json-schema-faker": "^0.5.0-rc16",
@@ -1101,11 +1100,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/js-base64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
-      "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw=="
     },
     "node_modules/js-sdsl": {
       "version": "4.1.5",
@@ -2857,11 +2851,6 @@
         "lex-parser": "0.1.x",
         "nomnom": "1.5.2"
       }
-    },
-    "js-base64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
-      "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw=="
     },
     "js-sdsl": {
       "version": "4.1.5",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "dependencies": {
     "debug": "^3.1.0",
     "faker": "^4.1.0",
-    "js-base64": "^2.4.5",
     "js-yaml": "^3.13.1",
     "json-refs": "^3.0.13",
     "json-schema-faker": "^0.5.0-rc16",


### PR DESCRIPTION
Just use Buffer.toString("base64") to encode base64 strings
